### PR TITLE
Fix Worker deploy: stop bundling React (global is not defined)

### DIFF
--- a/functions/src/doCron.spec.ts
+++ b/functions/src/doCron.spec.ts
@@ -7,10 +7,10 @@ import {
   Roadall,
   updateGoal,
   getGoal,
-  setNow,
   now,
   SID,
 } from "../../src/lib";
+import { setNow } from "../../src/lib/test/helpers";
 import { getUsers } from "./database";
 import { makeGoal } from "./test/helpers";
 

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -11,14 +11,12 @@ import {
   getGoal,
   getGoals,
   getGoalsVerbose,
-  setNow,
   GoalVerbose,
   parseDate,
-  r,
-  withMutedReactQueryLogger,
   now,
   SID,
 } from "./lib";
+import { setNow, r, withMutedReactQueryLogger } from "./lib/test/helpers";
 import { GoalInput, makeGoal } from "../functions/src/test/helpers";
 import { remove, update } from "./lib/functions";
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,4 @@
 export * from "./beeminder";
-export * from "./test/helpers";
 export * from "./dial";
 export * from "./types";
 export * from "./time";


### PR DESCRIPTION
## Why

The deploy-on-merge for #54 failed at Worker upload:

```
✘ A request to the Cloudflare API (/workers/scripts/autodial) failed.
  Uncaught ReferenceError: global is not defined
    at .../@testing-library/dom/.../pretty-format/AsymmetricMatcher.js  [code: 10021]
```

## Root cause

`src/lib/index.ts` (the production barrel the Worker imports from) did
`export * from "./test/helpers"` — a React `.tsx`. Bundling `src/lib` for the
Worker therefore pulled in `@testing-library/dom`, whose `pretty-format`
references `global`, which doesn't exist in the Workers runtime → the uploaded
script throws at validation.

## Fix

- Remove the test-helper re-export from `src/lib/index.ts`.
- Import `setNow`/`r`/`withMutedReactQueryLogger` directly from
  `lib/test/helpers` in the two specs that got them via the barrel
  (`src/App.spec.tsx`, `functions/src/doCron.spec.ts`).

Verified with `wrangler deploy --dry-run`: the bundle no longer contains
testing-library/react and drops **2044 KiB → 408 KiB**. Both jest suites green
(web 80, functions 29).

Partial fix for #55 (the deps/`jsx` cleanup that this now enables is still tracked there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal module organization by separating test utilities from shared application exports.
  - Centralized Beeminder-related exports for more consistent access across the application.

- **Tests**
  - Updated test imports to use dedicated test helpers without changing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->