### PR TITLE
Run the dialer cron daily, not hourly

### DIFF
--- a/functions/wrangler.toml
+++ b/functions/wrangler.toml
@@ -16,9 +16,10 @@ not_found_handling = "single-page-application"
 cpu_ms = 300000
 
 # Cron trigger replaces the old public HTTP cron endpoint + Cloud Scheduler.
-# Adjust cadence as desired; the UI promises "once a day at minimum".
+# Must stay DAILY (once): dialing is not frequency-independent, so extra runs
+# over-shift low-history goals. See #57 before increasing the frequency.
 [triggers]
-crons = ["0 * * * *"]
+crons = ["0 0 * * *"]
 
 [[kv_namespaces]]
 binding = "USERS"


### PR DESCRIPTION
Changes the cron trigger from hourly (`0 * * * *`) to **daily** (`0 0 * * *`, midnight UTC), matching the old production schedule.

Dialing isn't frequency-independent: the maturity weighting adjusts a goal's rate per run, so running more often over-shifts low-history goals. Until that's fixed (**#57**), the cadence must stay daily.

Config-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)