### PR TITLE
Add Sentry error tracking (Worker + frontend)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 REACT_APP_BM_CLIENT_ID=<yourTestClientId>
 REACT_APP_APP_URL=http://localhost:3000
 REACT_APP_API_URL=http://localhost:8787
+# Optional: Sentry DSN for the frontend (leave empty to disable)
+REACT_APP_SENTRY_DSN=

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,6 +30,7 @@ jobs:
           REACT_APP_API_URL: ""
           REACT_APP_APP_URL: ${{ secrets.REACT_APP_APP_URL }}
           REACT_APP_BM_CLIENT_ID: ${{ secrets.REACT_APP_BM_CLIENT_ID }}
+          REACT_APP_SENTRY_DSN: ${{ secrets.REACT_APP_SENTRY_DSN }}
       - name: Deploy Worker (SPA assets + API + cron)
         run: npx wrangler deploy
         working-directory: ./functions

--- a/README.md
+++ b/README.md
@@ -70,3 +70,14 @@ the static assets, and the cron trigger together. Requires `CLOUDFLARE_API_TOKEN
 and `CLOUDFLARE_ACCOUNT_ID` repo secrets, plus the `REACT_APP_APP_URL` and
 `REACT_APP_BM_CLIENT_ID` build secrets (`REACT_APP_API_URL` is left empty in
 prod — same origin). The cron cadence is set in `functions/wrangler.toml`.
+
+## Error tracking (Sentry)
+
+Both halves are optional and no-op until their DSN is set:
+
+- **Frontend** — `REACT_APP_SENTRY_DSN` repo secret (baked into the build).
+- **Worker** — a `SENTRY_DSN` Worker secret, set once with
+  `cd functions && wrangler secret put SENTRY_DSN` (not a build var; the deploy
+  doesn't provision it).
+
+Beeminder tokens are scrubbed from URLs before events are sent (`redactToken`).

--- a/functions/.dev.vars.example
+++ b/functions/.dev.vars.example
@@ -1,3 +1,7 @@
 # Copy to .dev.vars for `wrangler dev`. Keeps local runs from writing real
 # goals back to Beeminder (the old Firebase emulator did this automatically).
 DRY_RUN=true
+
+# Optional: Sentry DSN for the Worker (unset disables Sentry). In production set
+# it once with: wrangler secret put SENTRY_DSN
+SENTRY_DSN=

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "functions",
       "dependencies": {
+        "@sentry/cloudflare": "^8.47.0",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
@@ -32,7 +33,7 @@
         "wrangler": "^3.78.0"
       },
       "engines": {
-        "node": "16"
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -752,7 +753,7 @@
       "version": "4.20260702.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
       "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1980,6 +1981,30 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@sentry/cloudflare": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cloudflare/-/cloudflare-8.55.2.tgz",
+      "integrity": "sha512-8fsMsMzK/2qX/ewrVnJke3Lu5XmGBrTkX/8diZpRDNT9lZ7h+Ixbn8BnJcenD+orsfS1+o+ptxNRFZAbyuuXGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.55.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workers-types": "^4.x"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.2.tgz",
+      "integrity": "sha512-YlEBwybUcOQ/KjMHDmof1vwweVnBtBxYlQp7DE3fOdtW4pqqdHWTnTntQs4VgYfxzjJYgtkd9LHlGtg8qy+JVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "node_modules/@sinonjs/commons": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -30,6 +30,7 @@
     "node": ">=18"
   },
   "dependencies": {
+    "@sentry/cloudflare": "^8.47.0",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",

--- a/functions/src/doCron.spec.ts
+++ b/functions/src/doCron.spec.ts
@@ -14,6 +14,7 @@ import { setNow } from "../../src/lib/test/helpers";
 import { getUsers } from "./database";
 import { makeGoal } from "./test/helpers";
 
+jest.mock("@sentry/cloudflare");
 jest.mock("../../src/lib/log");
 jest.mock("./database");
 jest.mock("../../src/lib/dial");

--- a/functions/src/doCron.ts
+++ b/functions/src/doCron.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/cloudflare";
 import {getUsers} from "./database";
 import log from "../../src/lib/log";
 import {
@@ -57,10 +58,12 @@ const doCron = async (kv: KVNamespace, dryRun = false): Promise<void> => {
             );
           }
         } catch (e) {
+          Sentry.captureException(e, {extra: {beeminder_user, slug: g.slug}});
           log({m: "failed to dial goal", g, e});
         }
       }));
     } catch (e) {
+      Sentry.captureException(e, {extra: {beeminder_user}});
       log({m: "failed to handle user", beeminder_user, e});
     }
   }));

--- a/functions/src/index.spec.ts
+++ b/functions/src/index.spec.ts
@@ -1,8 +1,9 @@
-import worker, {Env} from "./index";
+import {handlers, Env} from "./index";
 import doUpdate from "./doUpdate";
 import doRemove from "./doRemove";
 import doCron from "./doCron";
 
+jest.mock("@sentry/cloudflare");
 jest.mock("./doUpdate");
 jest.mock("./doRemove");
 jest.mock("./doCron");
@@ -37,18 +38,18 @@ function req(method: string, path: string, body?: unknown): Request {
 
 describe("worker fetch", () => {
   it("answers OPTIONS preflight with CORS", async () => {
-    const res = await worker.fetch(req("OPTIONS", "/update"), env);
+    const res = await handlers.fetch(req("OPTIONS", "/update"), env);
     expect(res.status).toBe(204);
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
   });
 
   it("rejects non-POST methods", async () => {
-    const res = await worker.fetch(req("GET", "/update"), env);
+    const res = await handlers.fetch(req("GET", "/update"), env);
     expect(res.status).toBe(405);
   });
 
   it("routes /update to doUpdate", async () => {
-    const res = await worker.fetch(
+    const res = await handlers.fetch(
         req("POST", "/update", {user: "u", token: "t"}),
         env
     );
@@ -57,7 +58,7 @@ describe("worker fetch", () => {
   });
 
   it("routes /remove to doRemove", async () => {
-    const res = await worker.fetch(
+    const res = await handlers.fetch(
         req("POST", "/remove", {user: "u", token: "t"}),
         env
     );
@@ -66,13 +67,13 @@ describe("worker fetch", () => {
   });
 
   it("404s unknown paths", async () => {
-    const res = await worker.fetch(req("POST", "/nope", {}), env);
+    const res = await handlers.fetch(req("POST", "/nope", {}), env);
     expect(res.status).toBe(404);
   });
 
   it("500s when a handler throws", async () => {
     (doUpdate as jest.Mock).mockRejectedValueOnce(new Error("boom"));
-    const res = await worker.fetch(
+    const res = await handlers.fetch(
         req("POST", "/update", {user: "u", token: "t"}),
         env
     );
@@ -82,7 +83,7 @@ describe("worker fetch", () => {
 
 describe("worker scheduled", () => {
   it("dials all users, passing the DRY_RUN flag", async () => {
-    await worker.scheduled(
+    await handlers.scheduled(
         {} as ScheduledController,
         {USERS: {} as KVNamespace, DRY_RUN: "true"}
     );

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -67,7 +67,7 @@ export default Sentry.withSentry(
       // The Beeminder token rides in outgoing fetch URLs; keep it out of the
       // breadcrumb trail and the captured event.
       beforeBreadcrumb(breadcrumb) {
-        if (breadcrumb.data?.url) {
+        if (typeof breadcrumb.data?.url === "string") {
           breadcrumb.data.url = redactToken(breadcrumb.data.url);
         }
         return breadcrumb;
@@ -76,8 +76,14 @@ export default Sentry.withSentry(
         if (event.request?.url) {
           event.request.url = redactToken(event.request.url);
         }
+        // We never want the request body (it carries the token) in an event.
+        if (event.request?.data) {
+          event.request.data = "[REDACTED]";
+        }
         event.breadcrumbs?.forEach((b) => {
-          if (b.data?.url) b.data.url = redactToken(b.data.url);
+          if (typeof b.data?.url === "string") {
+            b.data.url = redactToken(b.data.url);
+          }
         });
         return event;
       },

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/cloudflare";
 import doCron from "./doCron";
 import doUpdate from "./doUpdate";
 import doRemove from "./doRemove";
@@ -6,6 +7,8 @@ export interface Env {
   USERS: KVNamespace;
   // "true" locally to skip writing goals back to Beeminder (wrangler dev)
   DRY_RUN?: string;
+  // Sentry DSN; unset disables Sentry (no-op).
+  SENTRY_DSN?: string;
 }
 
 const CORS = {
@@ -15,7 +18,8 @@ const CORS = {
   "Access-Control-Max-Age": "3600",
 };
 
-export default {
+// Exported unwrapped for tests; the default export wraps these with Sentry.
+export const handlers = {
   // Cron trigger — replaces the old public HTTP cron endpoint
   // + Cloud Scheduler.
   async scheduled(_event: ScheduledController, env: Env): Promise<void> {
@@ -46,8 +50,22 @@ export default {
 
       return new Response("Success", {status: 200, headers: CORS});
     } catch (e) {
+      Sentry.captureException(e);
       console.error(e);
       return new Response("Error", {status: 500, headers: CORS});
     }
   },
 };
+
+export default Sentry.withSentry(
+    (env: Env) => ({
+      dsn: env.SENTRY_DSN,
+      // Errors only; no performance tracing.
+      tracesSampleRate: 0,
+    }),
+    // @sentry/cloudflare's declared handler Request type diverges from our
+    // workers-types Request; the shape is correct at runtime (handlers is
+    // fully typed above).
+    // @ts-expect-error - upstream workers-types Request skew
+    handlers
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/cloudflare";
 import doCron from "./doCron";
 import doUpdate from "./doUpdate";
 import doRemove from "./doRemove";
+import {redactToken} from "../../src/lib/redactToken";
 
 export interface Env {
   USERS: KVNamespace;
@@ -62,10 +63,28 @@ export default Sentry.withSentry(
       dsn: env.SENTRY_DSN,
       // Errors only; no performance tracing.
       tracesSampleRate: 0,
+      sendDefaultPii: false,
+      // The Beeminder token rides in outgoing fetch URLs; keep it out of the
+      // breadcrumb trail and the captured event.
+      beforeBreadcrumb(breadcrumb) {
+        if (breadcrumb.data?.url) {
+          breadcrumb.data.url = redactToken(breadcrumb.data.url);
+        }
+        return breadcrumb;
+      },
+      beforeSend(event) {
+        if (event.request?.url) {
+          event.request.url = redactToken(event.request.url);
+        }
+        event.breadcrumbs?.forEach((b) => {
+          if (b.data?.url) b.data.url = redactToken(b.data.url);
+        });
+        return event;
+      },
     }),
     // @sentry/cloudflare's declared handler Request type diverges from our
     // workers-types Request; the shape is correct at runtime (handlers is
-    // fully typed above).
-    // @ts-expect-error - upstream workers-types Request skew
-    handlers
+    // fully typed above). Cast to withSentry's own param type (avoids the
+    // ban-ts-comment rule that forbids @ts-expect-error here).
+    handlers as unknown as Parameters<typeof Sentry.withSentry>[1]
 );

--- a/functions/wrangler.toml
+++ b/functions/wrangler.toml
@@ -1,6 +1,8 @@
 name = "autodial"
 main = "src/index.ts"
 compatibility_date = "2026-07-19"
+# Required by @sentry/cloudflare (AsyncLocalStorage).
+compatibility_flags = ["nodejs_compat"]
 
 # Serve the built SPA as static assets from this same Worker (no Cloudflare
 # Pages). Non-asset, non-GET requests (the /update, /remove POSTs) fall through

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/icons-material": "^5.3.1",
         "@mui/lab": "^5.0.0-alpha.63",
         "@mui/material": "^5.2.7",
+        "@sentry/react": "^7.120.3",
         "@testing-library/jest-dom": "^5.11.4",
         "@testing-library/react": "^11.1.0",
         "@testing-library/user-event": "^12.1.10",
@@ -4407,6 +4408,151 @@
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.120.4.tgz",
+      "integrity": "sha512-eSwgvTdrh03zYYaI6UVOjI9p4VmKg6+c2+CBQfRZX++6wwnCVsNv7XF7WUIpVGBAkJ0N2oapjQmCzJKGKBRWQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.120.4.tgz",
+      "integrity": "sha512-2+W4CgUL1VzrPjArbTid4WhKh7HH21vREVilZdvffQPVwOEpgNTPAb69loQuTlhJVveh9hWTj2nE5UXLbLP+AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.4",
+        "@sentry/replay": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.4.tgz",
+      "integrity": "sha512-Fz5+4XCg3akeoFK+K7g+d7HqGMjmnLoY2eJlpONJmaeT9pXY7yfUyXKZMmMajdE2LxxKJgQ2YKvSCaGVamTjHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.120.4.tgz",
+      "integrity": "sha512-ymlNtIPG6HAKzM/JXpWVGCzCNufZNADfy+O/olZuVJW5Be1DtOFyRnBvz0LeKbmxJbXb2lX/XMhuen6PXPdoQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/feedback": "7.120.4",
+        "@sentry-internal/replay-canvas": "7.120.4",
+        "@sentry-internal/tracing": "7.120.4",
+        "@sentry/core": "7.120.4",
+        "@sentry/integrations": "7.120.4",
+        "@sentry/replay": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.4.tgz",
+      "integrity": "sha512-TXu3Q5kKiq8db9OXGkWyXUbIxMMuttB5vJ031yolOl5T/B69JRyAoKuojLBjRv1XX583gS1rSSoX8YXX7ATFGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.4.tgz",
+      "integrity": "sha512-kkBTLk053XlhDCg7OkBQTIMF4puqFibeRO3E3YiVc4PGLnocXMaVpOSCkMqAc1k1kZ09UgGi8DxfQhnFEjUkpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4",
+        "localforage": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.120.4.tgz",
+      "integrity": "sha512-Pj1MSezEncE+5riuwsk8peMncuz5HR72Yr1/RdZhMZvUxoxAR/tkwD3aPcK6ddQJTagd2TGwhdr9SHuDLtONew==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "7.120.4",
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "15.x || 16.x || 17.x || 18.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.120.4.tgz",
+      "integrity": "sha512-FW8sPenNFfnO/K7sncsSTX4rIVak9j7VUiLIagJrcqZIC7d1dInFNjy8CdVJUlyz3Y3TOgIl3L3+ZpjfyMnaZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.120.4",
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.4.tgz",
+      "integrity": "sha512-cUq2hSSe6/qrU6oZsEP4InMI5VVdD86aypE+ENrQ6eZEVLTCYm1w6XhW1NvIu3UuWh7gZec4a9J7AFpYxki88Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.4.tgz",
+      "integrity": "sha512-zCKpyDIWKHwtervNK2ZlaK8mMV7gVUijAgFeJStH+CU/imcdquizV3pFLlSQYRswG+Lbyd6CT/LGRh3IbtkCFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -11858,6 +12004,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immer": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
@@ -16349,6 +16501,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -16373,6 +16534,15 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {
@@ -27735,6 +27905,108 @@
         }
       }
     },
+    "@sentry-internal/feedback": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.120.4.tgz",
+      "integrity": "sha512-eSwgvTdrh03zYYaI6UVOjI9p4VmKg6+c2+CBQfRZX++6wwnCVsNv7XF7WUIpVGBAkJ0N2oapjQmCzJKGKBRWQg==",
+      "requires": {
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      }
+    },
+    "@sentry-internal/replay-canvas": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.120.4.tgz",
+      "integrity": "sha512-2+W4CgUL1VzrPjArbTid4WhKh7HH21vREVilZdvffQPVwOEpgNTPAb69loQuTlhJVveh9hWTj2nE5UXLbLP+AA==",
+      "requires": {
+        "@sentry/core": "7.120.4",
+        "@sentry/replay": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      }
+    },
+    "@sentry-internal/tracing": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.4.tgz",
+      "integrity": "sha512-Fz5+4XCg3akeoFK+K7g+d7HqGMjmnLoY2eJlpONJmaeT9pXY7yfUyXKZMmMajdE2LxxKJgQ2YKvSCaGVamTjHw==",
+      "requires": {
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      }
+    },
+    "@sentry/browser": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.120.4.tgz",
+      "integrity": "sha512-ymlNtIPG6HAKzM/JXpWVGCzCNufZNADfy+O/olZuVJW5Be1DtOFyRnBvz0LeKbmxJbXb2lX/XMhuen6PXPdoQw==",
+      "requires": {
+        "@sentry-internal/feedback": "7.120.4",
+        "@sentry-internal/replay-canvas": "7.120.4",
+        "@sentry-internal/tracing": "7.120.4",
+        "@sentry/core": "7.120.4",
+        "@sentry/integrations": "7.120.4",
+        "@sentry/replay": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      }
+    },
+    "@sentry/core": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.4.tgz",
+      "integrity": "sha512-TXu3Q5kKiq8db9OXGkWyXUbIxMMuttB5vJ031yolOl5T/B69JRyAoKuojLBjRv1XX583gS1rSSoX8YXX7ATFGA==",
+      "requires": {
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      }
+    },
+    "@sentry/integrations": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.4.tgz",
+      "integrity": "sha512-kkBTLk053XlhDCg7OkBQTIMF4puqFibeRO3E3YiVc4PGLnocXMaVpOSCkMqAc1k1kZ09UgGi8DxfQhnFEjUkpA==",
+      "requires": {
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4",
+        "localforage": "^1.8.1"
+      }
+    },
+    "@sentry/react": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.120.4.tgz",
+      "integrity": "sha512-Pj1MSezEncE+5riuwsk8peMncuz5HR72Yr1/RdZhMZvUxoxAR/tkwD3aPcK6ddQJTagd2TGwhdr9SHuDLtONew==",
+      "requires": {
+        "@sentry/browser": "7.120.4",
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4",
+        "hoist-non-react-statics": "^3.3.2"
+      }
+    },
+    "@sentry/replay": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.120.4.tgz",
+      "integrity": "sha512-FW8sPenNFfnO/K7sncsSTX4rIVak9j7VUiLIagJrcqZIC7d1dInFNjy8CdVJUlyz3Y3TOgIl3L3+ZpjfyMnaZg==",
+      "requires": {
+        "@sentry-internal/tracing": "7.120.4",
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      }
+    },
+    "@sentry/types": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.4.tgz",
+      "integrity": "sha512-cUq2hSSe6/qrU6oZsEP4InMI5VVdD86aypE+ENrQ6eZEVLTCYm1w6XhW1NvIu3UuWh7gZec4a9J7AFpYxki88Q=="
+    },
+    "@sentry/utils": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.4.tgz",
+      "integrity": "sha512-zCKpyDIWKHwtervNK2ZlaK8mMV7gVUijAgFeJStH+CU/imcdquizV3pFLlSQYRswG+Lbyd6CT/LGRh3IbtkCFw==",
+      "requires": {
+        "@sentry/types": "7.120.4"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -33496,6 +33768,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "immer": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
@@ -36859,6 +37136,14 @@
         "type-check": "~0.4.0"
       }
     },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -36877,6 +37162,14 @@
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
         "json5": "^2.1.2"
+      }
+    },
+    "localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "requires": {
+        "lie": "3.1.1"
       }
     },
     "locate-path": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@mui/icons-material": "^5.3.1",
     "@mui/lab": "^5.0.0-alpha.63",
     "@mui/material": "^5.2.7",
+    "@sentry/react": "^7.120.3",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import * as Sentry from "@sentry/react";
 import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
+import {redactToken} from "./lib/redactToken";
 import {QueryClient, QueryClientProvider} from "react-query";
 
 // No-op unless a DSN is configured (REACT_APP_SENTRY_DSN build var).
@@ -11,6 +12,18 @@ if (process.env.REACT_APP_SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.REACT_APP_SENTRY_DSN,
     tracesSampleRate: 0,
+    sendDefaultPii: false,
+    // After the Beeminder OAuth redirect the token sits in the URL bar, which
+    // Sentry copies onto every event; scrub it before anything is sent.
+    beforeSend(event) {
+      if (event.request?.url) {
+        event.request.url = redactToken(event.request.url);
+      }
+      event.breadcrumbs?.forEach((b) => {
+        if (b.data?.url) b.data.url = redactToken(b.data.url);
+      });
+      return event;
+    },
   });
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,8 +19,21 @@ if (process.env.REACT_APP_SENTRY_DSN) {
       if (event.request?.url) {
         event.request.url = redactToken(event.request.url);
       }
+      if (event.request?.data) {
+        event.request.data = "[REDACTED]";
+      }
+      // Navigation breadcrumbs keep URLs in from/to (not url); b.data is `any`,
+      // so guard the type before scrubbing to avoid throwing in beforeSend.
       event.breadcrumbs?.forEach((b) => {
-        if (b.data?.url) b.data.url = redactToken(b.data.url);
+        if (typeof b.data?.url === "string") {
+          b.data.url = redactToken(b.data.url);
+        }
+        if (typeof b.data?.from === "string") {
+          b.data.from = redactToken(b.data.from);
+        }
+        if (typeof b.data?.to === "string") {
+          b.data.to = redactToken(b.data.to);
+        }
       });
       return event;
     },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,18 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import * as Sentry from "@sentry/react";
 import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 import {QueryClient, QueryClientProvider} from "react-query";
+
+// No-op unless a DSN is configured (REACT_APP_SENTRY_DSN build var).
+if (process.env.REACT_APP_SENTRY_DSN) {
+  Sentry.init({
+    dsn: process.env.REACT_APP_SENTRY_DSN,
+    tracesSampleRate: 0,
+  });
+}
 
 const queryClient = new QueryClient();
 

--- a/src/lib/redactToken.spec.ts
+++ b/src/lib/redactToken.spec.ts
@@ -1,0 +1,18 @@
+import {redactToken} from "./redactToken";
+
+describe("redactToken", () => {
+  it("redacts an access_token query param", () => {
+    expect(redactToken("https://x/goals.json?access_token=secret123&x=1"))
+        .toBe("https://x/goals.json?access_token=REDACTED&x=1");
+  });
+
+  it("redacts a token at the end of the query", () => {
+    expect(redactToken("https://x/u.json?filter=a&access_token=secret123"))
+        .toBe("https://x/u.json?filter=a&access_token=REDACTED");
+  });
+
+  it("leaves URLs without a token untouched", () => {
+    expect(redactToken("https://x/goals.json?filter=frontburner"))
+        .toBe("https://x/goals.json?filter=frontburner");
+  });
+});

--- a/src/lib/redactToken.ts
+++ b/src/lib/redactToken.ts
@@ -1,0 +1,5 @@
+// Beeminder access tokens ride in request URLs (?access_token=...). Sentry's
+// default integrations copy URLs into breadcrumbs and event.request.url, so
+// scrub the token before anything is sent.
+export const redactToken = (url: string): string =>
+  url.replace(/access_token=[^&#]+/gi, "access_token=REDACTED");


### PR DESCRIPTION
## What

Adds Sentry error tracking to both runtime surfaces so we have visibility into issues:

- **Worker** (`@sentry/cloudflare`): wraps the exported handler with `withSentry`, and captures the exceptions that `doCron` otherwise swallows (per-user / per-goal) plus the `fetch` handler's 500 path. Requires the `nodejs_compat` flag.
- **Frontend** (`@sentry/react`): `Sentry.init` in `index.tsx`.

Both **no-op unless their DSN is set**, so nothing breaks before Sentry is configured.

## Token safety

The default Sentry integrations copy request URLs into breadcrumbs / `event.request.url`, and the Beeminder token rides in fetch URLs (and, post-OAuth, the browser URL bar). A shared `redactToken` scrubber (with a test) strips `access_token=…` from URLs on both surfaces via `beforeSend`/`beforeBreadcrumb`, and `sendDefaultPii: false` is set explicitly. Follow-up **#59** tracks removing the token from the URL bar entirely (the proper fix; this is defense-in-depth).

## Setup required (both optional, no-op until set)

- Frontend: `REACT_APP_SENTRY_DSN` repo secret (wired into the build).
- Worker: `SENTRY_DSN` Worker secret — `cd functions && wrangler secret put SENTRY_DSN` (the deploy doesn't provision it; documented in README + `.dev.vars.example`).

Also deletes the now-unused `FIREBASE_TOKEN` repo secret (done separately, not in this diff).

## Notes

- Handlers are exported unwrapped (`handlers`) and tested directly; the `withSentry`-wrapped default (what runs in prod) is a thin library call verified via `wrangler dev` but not unit-tested (jest 27 + the SDK's ESM make that fragile).
- Tests: web 83, functions 29, both green. tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Sentry error tracking for the frontend and backend.
  * Added contextual error reporting for failed requests and scheduled operations.
  * Automatically redacts access tokens from error-tracking URLs and breadcrumbs.
  * Sentry performance tracing and personally identifiable information collection are disabled by default.

* **Documentation**
  * Added setup instructions for configuring Sentry in development and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->